### PR TITLE
Add default define options

### DIFF
--- a/config/database.js
+++ b/config/database.js
@@ -4,7 +4,11 @@ module.exports = {
     password: null,
     database: 'database_development',
     host: '127.0.0.1',
-    dialect: 'mysql'
+    dialect: 'mysql',
+    define: {
+      underscored: true,
+      underscoredAll: true
+    }
   },
   test: {
     username: 'root',


### PR DESCRIPTION
Added default 'define' options for model schema. This way we don't have to specify 'underscored' and 'underscoredAll' in every model file.